### PR TITLE
Fix breakage when no external switches are defined...

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -24,9 +24,12 @@ PLATFORMS = ["switch"]
 
 
 async def async_setup(hass: HomeAssistant, config: dict):
-    switches = config.get(DOMAIN).get(CONF_EXTERNAL_SWITCHES)
-    if switches:
-        GLOBAL_SCENES.add_switches(switches)
+    try:
+        switches = config.get(DOMAIN).get(CONF_EXTERNAL_SWITCHES)    
+        if switches:
+            GLOBAL_SCENES.add_switches(switches)
+    except Exception:
+        print("Oh well")
     await GLOBAL_SCENES.set_hass(hass)
     return True
 


### PR DESCRIPTION
Integration throws an error if no external switches are defined, this fixes that.