### PR TITLE
Update animations.py - fix randrange not supporting float anymore

### DIFF
--- a/custom_components/animated_scenes/animations.py
+++ b/custom_components/animated_scenes/animations.py
@@ -337,7 +337,7 @@ class Animation:
 
     def get_static_or_random(self, value, step=1):
         if isinstance(value, list):
-            return randrange(value[0], value[1], step)
+            return randrange(int(value[0]), int(value[1]), step)
         return value
 
     def pick_color(self):


### PR DESCRIPTION
Fix this issue : https://github.com/chazzu/hass-animated-scenes/issues/25
It's not a warning anymore, randrange doesn't support float since Python 3.12