### PR TITLE
Fix light selector in config_flow

### DIFF
--- a/custom_components/animated_scenes/const.py
+++ b/custom_components/animated_scenes/const.py
@@ -81,6 +81,7 @@ ERROR_TRANSITION_NOT_INT_OR_RANGE = "transition_not_int_or_range"
 ERROR_COLORS_IS_BLANK = "colors_is_blank"
 ERROR_COLORS_MALFORMED = "colors_malformed"
 ERROR_BRIGHTNESS_NOT_INT_OR_RANGE = "brightness_not_int_or_range"
+ERROR_MUST_SELECT_LIGHTS = "must_select_lights"
 ABORT_ACTIVITY_SENSOR_NO_OPTIONS = "activity_sensor_no_options"
 ABORT_INTEGRATION_NO_OPTIONS = "integration_no_options"
 

--- a/custom_components/animated_scenes/translations/en.json
+++ b/custom_components/animated_scenes/translations/en.json
@@ -79,7 +79,8 @@
             "transition_not_int_or_range": "Transition Duration: Not an integer or range in format '[2,5]'. Min: 0, Max: 6553",
             "brightness_not_int_or_range": "Brightness: Not an integer or range in format '[125,255]'. Min: 0, Max: 255",
             "colors_is_blank": "Colors: Cannot be blank or empty",
-            "colors_malformed": "Colors: Invalid format"
+            "colors_malformed": "Colors: Invalid format",
+            "must_select_lights": "You must select at least one light for the animation"
         }
     },
     "options": {
@@ -154,7 +155,8 @@
             "transition_not_int_or_range": "Transition Duration: Not an integer or range in format '[2,5]'. Min: 0, Max: 6553",
             "brightness_not_int_or_range": "Brightness: Not an integer or range in format '[125,255]'. Min: 0, Max: 255",
             "colors_is_blank": "Colors: Cannot be blank or empty",
-            "colors_malformed": "Colors: Invalid format"
+            "colors_malformed": "Colors: Invalid format",
+            "must_select_lights": "You must select at least one light for the animation"
         },
         "abort": {
             "activity_sensor_no_options": "&nbsp;\n\nNo options are available for the Animated Scenes Activity Sensor",


### PR DESCRIPTION
This pull request refactors error handling and validation logic in the `animated_scenes` configuration flow, improving consistency and user feedback. It also updates the schema for selecting lights to ensure compatibility with Home Assistant's platform constants. The most important changes are grouped below:

**Validation Improvements:**

* Adds a check to ensure that at least one light is selected during scene configuration, providing clear error feedback if none are chosen. [[1]](diffhunk://#diff-bfb707e6ff6b4a98bdf47c83a233cea572ea4df346a701f65c84ba89ee1f2b1eR79) [[2]](diffhunk://#diff-bfb707e6ff6b4a98bdf47c83a233cea572ea4df346a701f65c84ba89ee1f2b1eR549-R550) [[3]](diffhunk://#diff-bfb707e6ff6b4a98bdf47c83a233cea572ea4df346a701f65c84ba89ee1f2b1eR802-R803)

**Schema Updates:**

* Updates the light selector schema to use `Platform.LIGHT` for domain specification and sets the default to an empty list, improving compatibility and preventing schema errors. [[1]](diffhunk://#diff-bfb707e6ff6b4a98bdf47c83a233cea572ea4df346a701f65c84ba89ee1f2b1eL16-R16) [[2]](diffhunk://#diff-bfb707e6ff6b4a98bdf47c83a233cea572ea4df346a701f65c84ba89ee1f2b1eL342-R354)

**Other Minor Fixes:**

* Ensures default values are correctly set and schema extension logic is streamlined for better maintainability. [[1]](diffhunk://#diff-bfb707e6ff6b4a98bdf47c83a233cea572ea4df346a701f65c84ba89ee1f2b1eL288-R289) [[2]](diffhunk://#diff-bfb707e6ff6b4a98bdf47c83a233cea572ea4df346a701f65c84ba89ee1f2b1eL342-R354)

These changes collectively improve the reliability, maintainability, and user experience of the configuration flow for animated scenes.

Fixes #54 