### PR TITLE
Set global brightness even if animate brightness is false

### DIFF
--- a/custom_components/animated_scenes/animations.py
+++ b/custom_components/animated_scenes/animations.py
@@ -436,6 +436,10 @@ class Animation:
             attributes["brightness"] = self.get_static_or_random(color[CONF_BRIGHTNESS])
         elif self._animate_brightness and self._global_brightness is not None:
             attributes["brightness"] = self.get_static_or_random(self._global_brightness)
+        elif isinstance(self._global_brightness, int):
+            attributes["brightness"] = self._global_brightness
+        elif isinstance(self._global_brightness, list):
+            _LOGGER.warning("Global brightness is a list but animate_brightness is False, ignoring")
 
         if CONF_BRIGHTNESS in color and color[CONF_COLOR_ONE_CHANGE_PER_TICK]:
             self._light_status[light] = {


### PR DESCRIPTION
This pull request introduces a small change to the brightness handling logic in the `build_light_attributes` method of `animations.py`. The update adds more robust handling for cases where `animate brightness` is `False`. If `global_brightness` is an integer use it. If  it is a list, show a warning.

Brightness handling improvements:

* Added logic to set `attributes["brightness"]` directly if `self._global_brightness` is an integer, and log a warning if it is a list and brightness animation is disabled.

Fixes #48 