### PR TITLE
Fix ignore_off logic

### DIFF
--- a/custom_components/animated_scenes/animations.py
+++ b/custom_components/animated_scenes/animations.py
@@ -344,11 +344,7 @@ class Animation:
         if state is None:
             _LOGGER.warning("Entity %s not found, skipping", entity_id)
             return
-        if (
-            state.state != "off"
-            and entity_id not in self._active_lights
-            or (state.state == "off" and self._ignore_off and entity_id not in self._active_lights)
-        ):
+        if entity_id not in self._active_lights and (state.state != "off" or not self._ignore_off):
             self._active_lights.append(entity_id)
 
     def add_lights(self, ids: list) -> None:


### PR DESCRIPTION
ignore_off logic wasn't working properly.

Logic simplification:

* Simplified the conditional statement in the `add_light` method to make it more readable and maintainable, ensuring that lights are only added to `_active_lights` if they are not already present and either not `off` or `ignore_off` is `False`. (`custom_components/animated_scenes/animations.py`)